### PR TITLE
Adpatation à DockerCompose 1.6.2 (cf issue 3020), entrypoint amélioré

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -4,8 +4,6 @@ RUN apt-get update && apt-get install -qyy jq wcalc curl
 
 RUN npm install -g istex-api-harvester
 
-RUN sed -i -e "s;^#\!/usr/bin/env node;#\!/usr/local/bin/node --stack-size=32000;" /usr/local/lib/node_modules/istex-api-harvester/istex-api-harvester.njs
-
 ARG XTRACTGID
 ARG XTRACTUID
 

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -4,11 +4,14 @@ services:
     build: 
       context: .
       args:
-        http_proxy:
-        https_proxy:
-        no_proxy:
-        XTRACTUID:
-        XTRACTGID:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+        - XTRACTUID
+        - XTRACTGID
     volumes:
       - $XTRACTDIR:/output
-    entrypoint: /usr/local/bin/istex-api-harvester
+    entrypoint:
+        - /usr/local/bin/node
+        - --stack-size=32000
+        - /usr/local/bin/istex-api-harvester

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -14,4 +14,5 @@ services:
     entrypoint:
         - /usr/local/bin/node
         - --stack-size=32000
+        - --max_old_space_size=4096
         - /usr/local/bin/istex-api-harvester


### PR DESCRIPTION
Cette PR amène une meilleure approche concernant l'appel docker du JS istex-api-harverster, comme discuté lors de la précédente PR, et elle adopte une solution de contournement qui concerne une régression sur docker-compose 1.6.2 (cf https://github.com/docker/compose/issues/3020)
